### PR TITLE
Add responsive ROI calculator modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -561,6 +561,34 @@
         </div>
     </div>
 
+    <div id="roiModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="roiModalTitle">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 id="roiModalTitle">ROI-калькулятор</h3>
+                <button class="modal-close" onclick="closeModal('roiModal')" aria-label="Закрыть модальное окно">&times;</button>
+            </div>
+            <div class="modal-body">
+                <div class="roi-calculator roi-advanced">
+                    <div class="roi-input-group">
+                        <label for="priceSlider">Стоимость оборудования: <span class="value" id="priceValue"></span></label>
+                        <input type="range" id="priceSlider" min="1000" max="100000" step="1000" value="10000">
+                    </div>
+                    <div class="roi-input-group">
+                        <label for="procSlider">Кол-во процедур в месяц: <span class="value" id="procValue"></span></label>
+                        <input type="range" id="procSlider" min="1" max="1000" step="1" value="1">
+                    </div>
+                    <div class="roi-input-group">
+                        <label for="marginSlider">Средняя маржа ($): <span class="value" id="marginValue"></span></label>
+                        <input type="range" id="marginSlider" min="1" max="500" step="1" value="1">
+                    </div>
+                    <p id="roiMonths">Окупаемость: 0 мес.</p>
+                    <p id="monthlyProfit">Месячная прибыль: $0</p>
+                    <p id="yearlyProfit">Годовая прибыль: $0</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
 </body>
 </html>
 <!-- END index_part4.html -->

--- a/main.js
+++ b/main.js
@@ -47,9 +47,34 @@ function initROI(calcEl){
   update();
 }
 
+function updateROI(){
+  const price  = +document.getElementById('priceSlider').value;
+  const procs  = +document.getElementById('procSlider').value;
+  const margin = +document.getElementById('marginSlider').value;
+  const base = price * procs;
+  const months = Math.ceil(price / (procs * margin));
+  const monthly = procs * margin;
+  const yearly = monthly * 12;
+  document.getElementById('priceValue').textContent  = `$${price.toLocaleString()}`;
+  document.getElementById('procValue').textContent   = procs;
+  document.getElementById('marginValue').textContent = `$${margin}`;
+  document.getElementById('roiMonths').textContent   = `Окупаемость: ${months} мес.`;
+  document.getElementById('monthlyProfit').textContent = `Месячная прибыль: $${monthly.toLocaleString()}`;
+  document.getElementById('yearlyProfit').textContent  = `Годовая прибыль: $${yearly.toLocaleString()}`;
+}
+
 document.addEventListener('DOMContentLoaded',()=>{
-  // инициализируем все калькуляторы
-  $$('.roi-calculator',true).forEach(initROI);
+  // инициализируем базовые калькуляторы
+  $$('.roi-calculator:not(.roi-advanced)',true).forEach(initROI);
+
+  // продвинутый ROI-калькулятор
+  if($('.roi-advanced')){
+    ['priceSlider','procSlider','marginSlider'].forEach(id=>{
+      const el = document.getElementById(id);
+      if(el) el.addEventListener('input',updateROI);
+    });
+    updateROI();
+  }
 
   // ----------------  SMOOTH SCROLL (offset для fixed header) -------------
   $$('a[href^="#"]',true).forEach(a=>{

--- a/style.css
+++ b/style.css
@@ -254,6 +254,14 @@ h2, h3, h4, h5, h6 { letter-spacing: 0.025em; }
 .roi-input-group{margin-bottom:12px;font-size:.95rem}
 .roi-result{font-weight: normal; margin-top:8px;font-size:1.1rem;}
 
+.roi-calculator{display:flex;gap:16px;align-items:center;flex-wrap:wrap;justify-content:center}
+.roi-calculator input[type=range]{width:100%;max-width:400px}
+.roi-calculator .roi-input-group{flex:1 1 200px}
+@media (max-width:600px){
+  .roi-calculator{flex-direction:column;text-align:center}
+  .roi-calculator p{margin:4px 0}
+}
+
 .video-wrapper{position:relative;padding-top:56.25%}
 .video-wrapper iframe{position:absolute;inset:0;width:100%;height:100%}
 


### PR DESCRIPTION
## Summary
- add advanced ROI calculator modal with three sliders
- style ROI calculator for responsive layout
- implement JS to update ROI values and initialize modal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685841ae1968832c8092577a2212d489