### PR TITLE
Add manual inputs to ROI calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -572,8 +572,8 @@
                     <div class="roi-input-group">
                         <label for="priceSlider">Стоимость оборудования: <span class="value" id="priceValue"></span></label>
                         <div class="roi-controls">
-                            <input type="range" id="priceSlider" min="1000" max="100000" step="1000" value="10000">
-                            <input type="number" class="manual-input" id="priceInput" min="1000" max="100000" step="1000" value="10000">
+                            <input type="range" id="priceSlider" min="1000" max="500000" step="1000" value="10000">
+                            <input type="number" class="manual-input" id="priceInput" min="1000" max="500000" step="1000" value="10000">
                         </div>
                     </div>
                     <div class="roi-input-group">
@@ -586,8 +586,8 @@
                     <div class="roi-input-group">
                         <label for="marginSlider">Средняя маржа ($): <span class="value" id="marginValue"></span></label>
                         <div class="roi-controls">
-                            <input type="range" id="marginSlider" min="1" max="500" step="1" value="1">
-                            <input type="number" class="manual-input" id="marginInput" min="1" max="500" step="1" value="1">
+                            <input type="range" id="marginSlider" min="1" max="1000" step="1" value="1">
+                            <input type="number" class="manual-input" id="marginInput" min="1" max="1000" step="1" value="1">
                         </div>
                     </div>
                     <p id="roiMonths">Окупаемость: 0 мес.</p>

--- a/index.html
+++ b/index.html
@@ -561,6 +561,43 @@
         </div>
     </div>
 
+    <div id="roiModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="roiModalTitle">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 id="roiModalTitle">ROI-калькулятор</h3>
+                <button class="modal-close" onclick="closeModal('roiModal')" aria-label="Закрыть модальное окно">&times;</button>
+            </div>
+            <div class="modal-body">
+                <div class="roi-calculator roi-advanced">
+                    <div class="roi-input-group">
+                        <label for="priceSlider">Стоимость оборудования: <span class="value" id="priceValue"></span></label>
+                        <div class="roi-controls">
+                            <input type="range" id="priceSlider" min="1000" max="500000" step="1000" value="10000">
+                            <input type="number" class="manual-input" id="priceInput" min="1000" max="500000" step="1000" value="10000">
+                        </div>
+                    </div>
+                    <div class="roi-input-group">
+                        <label for="procSlider">Кол-во процедур в месяц: <span class="value" id="procValue"></span></label>
+                        <div class="roi-controls">
+                            <input type="range" id="procSlider" min="1" max="1000" step="1" value="1">
+                            <input type="number" class="manual-input" id="procInput" min="1" max="1000" step="1" value="1">
+                        </div>
+                    </div>
+                    <div class="roi-input-group">
+                        <label for="marginSlider">Средняя маржа ($): <span class="value" id="marginValue"></span></label>
+                        <div class="roi-controls">
+                            <input type="range" id="marginSlider" min="1" max="1000" step="1" value="1">
+                            <input type="number" class="manual-input" id="marginInput" min="1" max="1000" step="1" value="1">
+                        </div>
+                    </div>
+                    <p id="roiMonths">Окупаемость: 0 мес.</p>
+                    <p id="monthlyProfit">Месячная прибыль: $0</p>
+                    <p id="yearlyProfit">Годовая прибыль: $0</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
 </body>
 </html>
 <!-- END index_part4.html -->

--- a/index.html
+++ b/index.html
@@ -572,8 +572,8 @@
                     <div class="roi-input-group">
                         <label for="priceSlider">Стоимость оборудования: <span class="value" id="priceValue"></span></label>
                         <div class="roi-controls">
-                            <input type="range" id="priceSlider" min="1000" max="500000" step="1000" value="10000">
-                            <input type="number" class="manual-input" id="priceInput" min="1000" max="500000" step="1000" value="10000">
+                            <input type="range" id="priceSlider" min="1000" max="100000" step="1000" value="10000">
+                            <input type="number" class="manual-input" id="priceInput" min="1000" max="100000" step="1000" value="10000">
                         </div>
                     </div>
                     <div class="roi-input-group">
@@ -586,8 +586,8 @@
                     <div class="roi-input-group">
                         <label for="marginSlider">Средняя маржа ($): <span class="value" id="marginValue"></span></label>
                         <div class="roi-controls">
-                            <input type="range" id="marginSlider" min="1" max="1000" step="1" value="1">
-                            <input type="number" class="manual-input" id="marginInput" min="1" max="1000" step="1" value="1">
+                            <input type="range" id="marginSlider" min="1" max="500" step="1" value="1">
+                            <input type="number" class="manual-input" id="marginInput" min="1" max="500" step="1" value="1">
                         </div>
                     </div>
                     <p id="roiMonths">Окупаемость: 0 мес.</p>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-```html
 <!-- index_part1.html -->
 <!DOCTYPE html>
 <html lang="ru">
@@ -193,12 +192,6 @@
             </div>
         </section>
 <!-- END index_part2.html -->
-
-        <section id="categories" class="categories-section">
-            <div class="container">
-                <h2 class="section-title neon-text">Наши категории оборудования</h2>
-                <div class="categories  
-                ```html
 <!-- index_part3.html -->
         <section id="categories" class="categories-section">
             <div class="container">

--- a/main.js
+++ b/main.js
@@ -47,9 +47,53 @@ function initROI(calcEl){
   update();
 }
 
+let priceSlider, procSlider, marginSlider;
+let priceInput, procInput, marginInput;
+
+function updateROI(){
+  const price  = +priceSlider.value;
+  const procs  = +procSlider.value;
+  const margin = +marginSlider.value;
+  priceInput.value = price;
+  procInput.value  = procs;
+  marginInput.value = margin;
+  const months = Math.ceil(price / (procs * margin));
+  const monthly = procs * margin;
+  const yearly = monthly * 12;
+  document.getElementById('priceValue').textContent  = `$${price.toLocaleString()}`;
+  document.getElementById('procValue').textContent   = procs;
+  document.getElementById('marginValue').textContent = `$${margin}`;
+  document.getElementById('roiMonths').textContent   = `Окупаемость: ${months} мес.`;
+  document.getElementById('monthlyProfit').textContent = `Месячная прибыль: $${monthly.toLocaleString()}`;
+  document.getElementById('yearlyProfit').textContent  = `Годовая прибыль: $${yearly.toLocaleString()}`;
+}
+
 document.addEventListener('DOMContentLoaded',()=>{
-  // инициализируем все калькуляторы
-  $$('.roi-calculator',true).forEach(initROI);
+  // инициализируем базовые калькуляторы
+  $$('.roi-calculator:not(.roi-advanced)',true).forEach(initROI);
+
+  // продвинутый ROI-калькулятор
+  if($('.roi-advanced')){
+    priceSlider = document.getElementById('priceSlider');
+    procSlider  = document.getElementById('procSlider');
+    marginSlider = document.getElementById('marginSlider');
+    priceInput  = document.getElementById('priceInput');
+    procInput   = document.getElementById('procInput');
+    marginInput = document.getElementById('marginInput');
+
+    const pairs = [
+      [priceSlider, priceInput],
+      [procSlider,  procInput],
+      [marginSlider, marginInput]
+    ];
+    pairs.forEach(([slider,input])=>{
+      if(slider && input){
+        slider.addEventListener('input',()=>{input.value=slider.value;updateROI();});
+        input.addEventListener('input',()=>{slider.value=input.value;updateROI();});
+      }
+    });
+    updateROI();
+  }
 
   // ----------------  SMOOTH SCROLL (offset для fixed header) -------------
   $$('a[href^="#"]',true).forEach(a=>{

--- a/main.js
+++ b/main.js
@@ -63,7 +63,10 @@ function updateROI(){
   document.getElementById('priceValue').textContent  = `$${price.toLocaleString()}`;
   document.getElementById('procValue').textContent   = procs;
   document.getElementById('marginValue').textContent = `$${margin}`;
-  document.getElementById('roiMonths').textContent   = `Окупаемость: ${months} мес.`;
+  const roiEl = document.getElementById('roiMonths');
+  roiEl.textContent = `Окупаемость: ${months} мес.`;
+  roiEl.classList.remove('green','yellow','red');
+  roiEl.classList.add(months<=6?'green':months<=12?'yellow':'red');
   document.getElementById('monthlyProfit').textContent = `Месячная прибыль: $${monthly.toLocaleString()}`;
   document.getElementById('yearlyProfit').textContent  = `Годовая прибыль: $${yearly.toLocaleString()}`;
 }

--- a/style.css
+++ b/style.css
@@ -259,9 +259,14 @@ h2, h3, h4, h5, h6 { letter-spacing: 0.025em; }
 .roi-calculator .roi-input-group{flex:1 1 200px}
 .roi-calculator .roi-input-group .roi-controls{display:flex;align-items:center;gap:8px;margin-top:6px}
 .roi-calculator .manual-input{width:90px;padding:8px 6px;border-radius:7px;border:1px solid #223344;background:#1a2540;color:#EEE;font-size:.95rem}
+.green{color:#00FF6A}
+.yellow{color:#FFC400}
+.red{color:#FF4D4D}
 @media (max-width:600px){
   .roi-calculator{flex-direction:column;text-align:center}
   .roi-calculator p{margin:4px 0}
+  .roi-calculator input[type=range],
+  .roi-calculator .manual-input{max-width:100%;width:100%}
 }
 
 .video-wrapper{position:relative;padding-top:56.25%}

--- a/style.css
+++ b/style.css
@@ -254,6 +254,16 @@ h2, h3, h4, h5, h6 { letter-spacing: 0.025em; }
 .roi-input-group{margin-bottom:12px;font-size:.95rem}
 .roi-result{font-weight: normal; margin-top:8px;font-size:1.1rem;}
 
+.roi-calculator{display:flex;gap:16px;align-items:center;flex-wrap:wrap;justify-content:center}
+.roi-calculator input[type=range]{width:100%;max-width:400px}
+.roi-calculator .roi-input-group{flex:1 1 200px}
+.roi-calculator .roi-input-group .roi-controls{display:flex;align-items:center;gap:8px;margin-top:6px}
+.roi-calculator .manual-input{width:90px;padding:8px 6px;border-radius:7px;border:1px solid #223344;background:#1a2540;color:#EEE;font-size:.95rem}
+@media (max-width:600px){
+  .roi-calculator{flex-direction:column;text-align:center}
+  .roi-calculator p{margin:4px 0}
+}
+
 .video-wrapper{position:relative;padding-top:56.25%}
 .video-wrapper iframe{position:absolute;inset:0;width:100%;height:100%}
 


### PR DESCRIPTION
## Summary
- sync sliders with manual number inputs in advanced ROI calculator
- expand price range and add controls for procedures and margin
- style `.manual-input` and layout for new controls

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685841ae1968832c8092577a2212d489